### PR TITLE
fix: 解决android11运行崩溃

### DIFF
--- a/app/src/main/java/com/fmt/kotlin/eyepetizer/SplashActivity.kt
+++ b/app/src/main/java/com/fmt/kotlin/eyepetizer/SplashActivity.kt
@@ -17,6 +17,7 @@ class SplashActivity : BaseBindActivity<ActivitySplashBinding>() {
         lifecycleScope.launchWhenCreated {
             delay(500)
             startActivity<HomeActivity>()
+            finish()
         }
     }
 }

--- a/config.gradle
+++ b/config.gradle
@@ -31,7 +31,8 @@ ext {
     ]
 
     dependencies = [
-            "logging-interceptor"          : "com.squareup.okhttp3:logging-interceptor:4.0.0",
+            "okhttp3"                      : "com.squareup.okhttp3:okhttp:4.9.1",
+            "logging-interceptor"          : "com.squareup.okhttp3:logging-interceptor:4.9.1",
             "retrofit2"                    : "com.squareup.retrofit2:retrofit:2.9.0",
             "converter-gson"               : "com.squareup.retrofit2:converter-gson:2.9.0",
             "immersionbar"                 : "com.gyf.immersionbar:immersionbar:3.0.0",

--- a/lib_common/build.gradle
+++ b/lib_common/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 
     api rootProject.ext.dependencies["logging-interceptor"]
     api rootProject.ext.dependencies["retrofit2"]
+    api rootProject.ext.dependencies["okhttp3"]
     api rootProject.ext.dependencies["converter-gson"]
     api rootProject.ext.dependencies["immersionbar"]
     api rootProject.ext.dependencies["immersionbar-ktx"]


### PR DESCRIPTION
由于okhttp3版本过低，在android11设备上运行时报错：`Caused by: java.lang.IllegalStateException: Expected Android API level 21+ but was 30`

升级okhttp3版本可解决该问题